### PR TITLE
Add --renderer=JUnit to synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Test2::Harness::Renderer::JUnit - Captures Test2::Harness results and emits a ju
 
 On the command line, with `yath`:
 
-    JUNIT_TEST_FILE="/tmp/foo.xml" ALLOW_PASSING_TODOS=1 yath test -j18 t/*.t
+    JUNIT_TEST_FILE="/tmp/test-output.xml" ALLOW_PASSING_TODOS=1 yath test --renderer=JUnit -j4 t/*.t
 
 # DESCRIPTION
 


### PR DESCRIPTION
change output file to be more explicit and avoid suggesting using `-j18` as default as most VMs would not be able to handle it