### PR TITLE
Change for future version of Test2-Harness

### DIFF
--- a/META.json
+++ b/META.json
@@ -34,8 +34,8 @@
          "requires" : {
             "File::Spec" : "0",
             "Storable" : "0",
-            "Test2::Harness::Renderer" : "0.001077",
-            "Test2::Harness::Util::HashBase" : "0.001077",
+            "Test2::Harness::Renderer" : "1.000000",
+            "Test2::Harness::Util::HashBase" : "1.000000",
             "XML::Generator" : "0",
             "perl" : "5.010001"
          }
@@ -58,6 +58,6 @@
          "url" : "https://github.com/cpanelinc/Test2-Harness-Renderer-JUnit"
       }
    },
-   "version" : "0.001077",
+   "version" : "1.000000",
    "x_serialization_backend" : "JSON::PP version 2.97001"
 }

--- a/META.yml
+++ b/META.yml
@@ -21,13 +21,13 @@ no_index:
 requires:
   File::Spec: '0'
   Storable: '0'
-  Test2::Harness::Renderer: '0.001077'
-  Test2::Harness::Util::HashBase: '0.001077'
+  Test2::Harness::Renderer: '1.000000'
+  Test2::Harness::Util::HashBase: '1.000000'
   XML::Generator: '0'
   perl: '5.010001'
 resources:
   bugtracker: https://github.com/cpanelinc/Test2-Harness-Renderer-JUnit/issues
   license: http://dev.perl.org/licenses/
   repository: https://github.com/cpanelinc/Test2-Harness-Renderer-JUnit
-version: '0.001077'
+version: '1.000000'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,8 +17,8 @@ my %WriteMakefileArgs = (
         'Test::More' => '0',
     },
     PREREQ_PM => {
-        'Test2::Harness::Renderer' => '0.001077',
-        'Test2::Harness::Util::HashBase' => '0.001077',
+        'Test2::Harness::Renderer' => '1.000000',
+        'Test2::Harness::Util::HashBase' => '1.000000',
         'File::Spec' => 0,
         'Storable' => 0,
         'XML::Generator' => 0,

--- a/lib/Test2/Harness/Renderer/JUnit.pm
+++ b/lib/Test2/Harness/Renderer/JUnit.pm
@@ -74,6 +74,7 @@ sub render_event {
                 'failures' => 0,
                 'tests'    => 0,
                 'name'     => _get_testsuite_name($test_file),
+                'id'       => $job_id, # add a UID in the XML output
             },
         };
 

--- a/lib/Test2/Harness/Renderer/JUnit.pm
+++ b/lib/Test2/Harness/Renderer/JUnit.pm
@@ -60,11 +60,6 @@ sub render_event {
         my $full_test_name = $job->{'file'};
         my $test_file      = File::Spec->abs2rel($full_test_name);
 
-        # Purge any previous runs of this job if we're seeing a new one starting.
-        foreach my $id ( keys %{ $self->{'tests'} } ) {
-            delete $self->{'tests'}->{$id} if $self->{'tests'}->{$id}->{name} eq $full_test_name;
-        }
-
         $self->{'tests'}->{$job_id} = {
             'name'           => $job->{'file'},
             'job_id'         => $job_id,

--- a/lib/Test2/Harness/Renderer/JUnit.pm
+++ b/lib/Test2/Harness/Renderer/JUnit.pm
@@ -11,6 +11,7 @@ our $VERSION = '0.001077';
 use Data::Dumper; $Data::Dumper::Sortkeys = 1;
 
 use File::Spec;
+use POSIX ();
 use Storable qw/dclone/;
 use XML::Generator ();
 
@@ -88,6 +89,7 @@ sub render_event {
         $self->close_open_failure_testcase( $test, -1 );
         $test->{'stop'} = $event->{'stamp'};
         $test->{'testsuite'}->{'time'} = $test->{'stop'} - $test->{'start'};
+        $test->{'testsuite'}->{'timestamp'} = _timestamp( $test->{'start'} );
 
         push @{ $test->{'testcase'} }, $self->xml->testcase( { 'name' => "Tear down.", 'time' => $stamp - $test->{'last_job_start'} }, "" );
 
@@ -312,6 +314,11 @@ sub _squeaky_clean {
     $string =~ s/([\x7f-\xff])/'[\\x'.sprintf('%02x',ord($1)).']'/ge;
     return $string;
 }
+
+sub _timestamp {
+     my $time = shift;
+     return POSIX::strftime('%Y-%m-%dT%H:%M:%S', localtime(int($time)));
+ }
 
 1;
 

--- a/lib/Test2/Harness/Renderer/JUnit.pm
+++ b/lib/Test2/Harness/Renderer/JUnit.pm
@@ -14,6 +14,7 @@ use File::Spec;
 use POSIX ();
 use Storable qw/dclone/;
 use XML::Generator ();
+use Carp ();
 
 BEGIN { require Test2::Harness::Renderer; our @ISA = ('Test2::Harness::Renderer') }
 use Test2::Harness::Util::HashBase qw{
@@ -53,7 +54,14 @@ sub render_event {
     my $f      = $event->{facet_data};
     my $job    = $f->{harness_job};
     my $job_id = $event->{'job_id'} or return;
-    my $stamp  = $event->{'stamp'} || die "No time stamp found for event?!?!?!?";
+    my $stamp  = $event->{'stamp'};
+
+    if ( !defined $stamp ) {
+        $f //= 'unknown facet_data';
+        die "No time stamp found for event '$f' ?!?!?!? ...\n"
+            . "Event:\n" . Dumper( $event ) . "\n"
+            . Carp::longmess();
+    }
 
     # At job launch we need to start collecting a new junit testdata section.
     # We throw out anything we've collected to date.

--- a/lib/Test2/Harness/Renderer/JUnit.pm
+++ b/lib/Test2/Harness/Renderer/JUnit.pm
@@ -5,7 +5,7 @@ use 5.010000;
 use strict;
 use warnings;
 
-our $VERSION = '0.001077';
+our $VERSION = '1.000000';
 
 # This is used frequently during development to determine what different events look like so we can determine how to capture test data.
 use Data::Dumper; $Data::Dumper::Sortkeys = 1;


### PR DESCRIPTION
The `major_refactor` branch seems clean, and now reuse the same job id on rerun.

This is adding the job id to the xml output and avoiding removing a job before it's finish.
This is an issue when for example running multiple times the same test like shown here:

`JUNIT_TEST_FILE="/tmp/output.xml" ALLOW_PASSING_TODOS=1 yath test -j18 --retry=12 --renderer=JUnit t/random.t t/random.t t/random.t t/random.t t/random.t;`

with something like
```perl
#╰─> cat t/random.t
use Test::More;

is int rand(4), 1, "1";

done_testing;
```
